### PR TITLE
feat: Added compile option for checking for updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 
 option(USE_XDG_DIRECTORY "Use XDG directory to store data instead of the working directory" ON)
+option(CHECK_FOR_UPDATES "Enables checking for updates from the Github repo" ON)
 
 add_executable(${PROJECT_NAME} main.cpp
         third-party/imgui/imconfig.h
@@ -54,6 +55,10 @@ if(USE_XDG_DIRECTORY)
   target_compile_definitions(${PROJECT_NAME} PUBLIC USE_XDG)
 endif(USE_XDG_DIRECTORY)
 
+
+if(CHECK_FOR_UPDATES)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC CHECK_FOR_UPDATES)
+endif(CHECK_FOR_UPDATES)
 
 
 find_package(PkgConfig REQUIRED)

--- a/Lampray/Menu/lampCustomise.h
+++ b/Lampray/Menu/lampCustomise.h
@@ -188,11 +188,12 @@ namespace Lamp {
                         ImGui::DragFloat(lampLang::LS("LAMPRAY_CUSTOM_FONT"), &io.FontGlobalScale, 0.005f, MIN_SCALE, MAX_SCALE, "%.2f",
                                          ImGuiSliderFlags_AlwaysClamp);
                     }
+#ifdef CHECK_FOR_UPDATES
                     if (ImGui::CollapsingHeader(lampLang::LS("LAMPRAY_UPDATE_RULES"))) {
                         ImGui::Checkbox(lampLang::LS("LAMPRAY_UPDATE_RULES1")+" (Check_Updates_Startup)",
                                         &lampConfig::getInstance().checkForUpdatesAtStartup);
                     }
-
+#endif
 
                 if (ImGui::CollapsingHeader(lampLang::LS("LAMPRAY_CUSTOM_LANG"))) {
                     std::vector<std::string> xmlFiles;

--- a/Lampray/Menu/lampMenu.cpp
+++ b/Lampray/Menu/lampMenu.cpp
@@ -283,10 +283,11 @@ void Lamp::Core::lampMenu::DefaultMenuBar() {
             }
 
 
-
+#ifdef CHECK_FOR_UPDATES
             if (ImGui::MenuItem(lampLang::LS("LAMPRAY_UPDATE_CHECK"))) {
                 Lamp::Core::FS::lampUpdate::getInstance().checkForUpdates();
             }
+#endif
 
             if (ImGui::MenuItem(lampLang::LS("LAMPRAY_CUSTOM"))) {
                 currentMenu = CUSTOMIZE;

--- a/main.cpp
+++ b/main.cpp
@@ -119,6 +119,9 @@ int main(int, char**)
     if(loadedCheckUpdates == "0" || loadedCheckUpdates == "false"){
         checkForUpdates = false;
     }
+#ifdef CHECK_FOR_UPDATES
+	checkForUpdates = false;
+#endif
     if(checkForUpdates){
         Lamp::Core::FS::lampUpdate::getInstance().checkForUpdates();
     }


### PR DESCRIPTION
Provides a compile option "CHECK_FOR_UPDATES" which defaults to ON. When turned OFF, it should disable the automatic update check during startup and remove the option to manually check from the app's menu.

This should address #121 and similar concerns for alternative builds.
